### PR TITLE
Refactor legacy generators into structured components

### DIFF
--- a/ConfigGenerator/ConfigGenerator.csproj
+++ b/ConfigGenerator/ConfigGenerator.csproj
@@ -37,7 +37,13 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Form1.cs" />
+    <Compile Include="Form1.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Form1.Designer.cs">
+      <DependentUpon>Form1.cs</DependentUpon>
+    </Compile>
+    <Compile Include="MuConfiguration.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.cs" />
     <Compile Include="Properties\Settings.cs" />

--- a/ConfigGenerator/Form1.Designer.cs
+++ b/ConfigGenerator/Form1.Designer.cs
@@ -1,0 +1,198 @@
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ConfigGenerator
+{
+    public partial class Form1
+    {
+        private Label S12;
+        private Label Url;
+        private TextBox textBoxUrl1;
+        private ComboBox comboBox1;
+        private Button Save;
+        private Label label2;
+        private TextBox txtboxName;
+        private Label label3;
+        private TextBox textBoxExe;
+        private Label label4;
+        private TextBox textBoxUrl2;
+        private Label label1;
+        private ComboBox comboBox2;
+        private IContainer components;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            var componentResourceManager = new ComponentResourceManager(typeof(Form1));
+            components = new Container();
+            S12 = new Label();
+            Url = new Label();
+            textBoxUrl1 = new TextBox();
+            comboBox1 = new ComboBox();
+            Save = new Button();
+            label2 = new Label();
+            txtboxName = new TextBox();
+            label3 = new Label();
+            textBoxExe = new TextBox();
+            label4 = new Label();
+            textBoxUrl2 = new TextBox();
+            label1 = new Label();
+            comboBox2 = new ComboBox();
+            SuspendLayout();
+            // 
+            // S12
+            // 
+            S12.AutoSize = true;
+            S12.Location = new Point(9, 41);
+            S12.Name = "S12";
+            S12.Size = new Size(74, 13);
+            S12.TabIndex = 0;
+            S12.Text = "Client Version:";
+            // 
+            // Url
+            // 
+            Url.AutoSize = true;
+            Url.Location = new Point(9, 68);
+            Url.Name = "Url";
+            Url.Size = new Size(61, 13);
+            Url.TabIndex = 2;
+            Url.Text = "Update Url:";
+            Url.Click += Url_Click;
+            // 
+            // textBoxUrl1
+            // 
+            textBoxUrl1.Location = new Point(77, 65);
+            textBoxUrl1.Name = "textBoxUrl1";
+            textBoxUrl1.Size = new Size(198, 20);
+            textBoxUrl1.TabIndex = 3;
+            textBoxUrl1.Text = "http://127.0.0.1/update/";
+            // 
+            // comboBox1
+            // 
+            comboBox1.FormattingEnabled = true;
+            comboBox1.Items.AddRange(new object[] { "Season 6", "Season 9", "Season 12" });
+            comboBox1.Location = new Point(99, 38);
+            comboBox1.Name = "comboBox1";
+            comboBox1.Size = new Size(176, 21);
+            comboBox1.TabIndex = 4;
+            // 
+            // Save
+            // 
+            Save.Location = new Point(99, 169);
+            Save.Name = "Save";
+            Save.Size = new Size(75, 23);
+            Save.TabIndex = 5;
+            Save.Text = "Save";
+            Save.UseVisualStyleBackColor = true;
+            Save.Click += Save_Click;
+            // 
+            // label2
+            // 
+            label2.AutoSize = true;
+            label2.Location = new Point(9, 15);
+            label2.Name = "label2";
+            label2.Size = new Size(38, 13);
+            label2.TabIndex = 7;
+            label2.Text = "Name:";
+            // 
+            // txtboxName
+            // 
+            txtboxName.Enabled = false;
+            txtboxName.Location = new Point(77, 12);
+            txtboxName.Name = "txtboxName";
+            txtboxName.Size = new Size(198, 20);
+            txtboxName.TabIndex = 8;
+            txtboxName.Text = "Mu Launcher";
+            // 
+            // label3
+            // 
+            label3.AutoSize = true;
+            label3.Location = new Point(9, 120);
+            label3.Name = "label3";
+            label3.Size = new Size(57, 13);
+            label3.TabIndex = 9;
+            label3.Text = "Exe name:";
+            // 
+            // textBoxExe
+            // 
+            textBoxExe.Location = new Point(77, 117);
+            textBoxExe.Name = "textBoxExe";
+            textBoxExe.Size = new Size(198, 20);
+            textBoxExe.TabIndex = 10;
+            textBoxExe.Text = "main.exe";
+            textBoxExe.TextChanged += textBox3_TextChanged;
+            // 
+            // label4
+            // 
+            label4.AutoSize = true;
+            label4.Location = new Point(9, 94);
+            label4.Name = "label4";
+            label4.Size = new Size(51, 13);
+            label4.TabIndex = 11;
+            label4.Text = "Page Url:";
+            // 
+            // textBoxUrl2
+            // 
+            textBoxUrl2.Location = new Point(77, 91);
+            textBoxUrl2.Name = "textBoxUrl2";
+            textBoxUrl2.Size = new Size(198, 20);
+            textBoxUrl2.TabIndex = 12;
+            textBoxUrl2.Text = "http://127.0.0.1/update/index.php";
+            // 
+            // label1
+            // 
+            label1.AutoSize = true;
+            label1.Location = new Point(9, 145);
+            label1.Name = "label1";
+            label1.Size = new Size(106, 13);
+            label1.TabIndex = 13;
+            label1.Text = "Launcher Language:";
+            // 
+            // comboBox2
+            // 
+            comboBox2.Enabled = false;
+            comboBox2.FormattingEnabled = true;
+            comboBox2.Items.AddRange(new object[] { "Auto", "Eng", "Spn", "Por" });
+            comboBox2.Location = new Point(121, 142);
+            comboBox2.Name = "comboBox2";
+            comboBox2.Size = new Size(154, 21);
+            comboBox2.TabIndex = 14;
+            // 
+            // Form1
+            // 
+            AutoScaleDimensions = new SizeF(6F, 13F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(287, 201);
+            Controls.Add(comboBox2);
+            Controls.Add(label1);
+            Controls.Add(textBoxUrl2);
+            Controls.Add(label4);
+            Controls.Add(textBoxExe);
+            Controls.Add(label3);
+            Controls.Add(txtboxName);
+            Controls.Add(label2);
+            Controls.Add(Save);
+            Controls.Add(comboBox1);
+            Controls.Add(textBoxUrl1);
+            Controls.Add(Url);
+            Controls.Add(S12);
+            Icon = (Icon)componentResourceManager.GetObject("$this.Icon");
+            MaximizeBox = false;
+            Name = "Form1";
+            Text = "Launcher Config";
+            Load += Form1_Load;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/ConfigGenerator/Form1.cs
+++ b/ConfigGenerator/Form1.cs
@@ -1,231 +1,85 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: ConfigGenerator.Form1
-// Assembly: ConfigGenerator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-// MVID: E333375F-E325-44D6-8F8A-127F1A7AB356
-// Assembly location: C:\Users\Rafael Mazzoni\Documents\Ideias de Revenda\RetroSix\Free Mu CMS 1.2.3\Launcher Free\Launcher Free\Generator\ConfigGenerator.exe
-
 using System;
-using System.ComponentModel;
-using System.Drawing;
 using System.IO;
-using System.Text;
 using System.Windows.Forms;
 
 namespace ConfigGenerator
 {
-  public class Form1 : Form
-  {
-    private byte[] Xor = new byte[5]
+    public partial class Form1 : Form
     {
-      (byte) 77,
-      (byte) 252,
-      (byte) 207,
-      (byte) 171,
-      byte.MaxValue
-    };
-    private const string FileName = ".\\\\mu.ini";
-    private IContainer components;
-    private Label S12;
-    private Label Url;
-    private TextBox textBoxUrl1;
-    private ComboBox comboBox1;
-    private Button Save;
-    private Label label2;
-    private TextBox txtboxName;
-    private Label label3;
-    private TextBox textBoxExe;
-    private Label label4;
-    private TextBox textBoxUrl2;
-    private Label label1;
-    private ComboBox comboBox2;
+        private readonly MuConfiguration _configuration;
 
-    public Form1() => this.InitializeComponent();
-
-    private void Save_Click(object sender, EventArgs e)
-    {
-      using (BinaryWriter binaryWriter = new BinaryWriter((Stream) new FileStream(".\\\\mu.ini", FileMode.Create)))
-      {
-        byte[] bytes = Encoding.UTF8.GetBytes(this.txtboxName.Text + "|" + this.textBoxUrl1.Text + "|" + this.textBoxExe.Text + "|" + this.textBoxUrl2.Text);
-        for (int index = 0; index < bytes.Length; ++index)
-          bytes[index] ^= this.Xor[index % 5];
-        binaryWriter.Write(this.comboBox1.SelectedIndex);
-        binaryWriter.Write(this.comboBox2.SelectedIndex);
-        binaryWriter.Write(bytes);
-        binaryWriter.Close();
-        int num = (int) MessageBox.Show("Created mu.ini", "NOTICE");
-      }
-    }
-
-    private void Form1_Load(object sender, EventArgs e)
-    {
-      this.comboBox1.SelectedIndex = 0;
-      this.comboBox2.SelectedIndex = 0;
-      try
-      {
-        using (BinaryReader binaryReader = new BinaryReader((Stream) new FileStream(".\\\\mu.ini", FileMode.Open)))
+        public Form1()
         {
-          this.comboBox1.SelectedIndex = binaryReader.ReadInt32();
-          this.comboBox2.SelectedIndex = binaryReader.ReadInt32();
-          byte[] bytes = binaryReader.ReadBytes((int) binaryReader.BaseStream.Length - 4);
-          for (int index = 0; index < bytes.Length; ++index)
-            bytes[index] ^= this.Xor[index % 5];
-          this.txtboxName.Text = Encoding.UTF8.GetString(bytes).Split('|')[0];
-          this.textBoxUrl1.Text = Encoding.UTF8.GetString(bytes).Split('|')[1];
-          this.textBoxExe.Text = Encoding.UTF8.GetString(bytes).Split('|')[2];
-          this.textBoxUrl2.Text = Encoding.UTF8.GetString(bytes).Split('|')[3];
-          binaryReader.Close();
+            InitializeComponent();
+            _configuration = MuConfiguration.Load();
         }
-      }
-      catch
-      {
-      }
-    }
 
-    private void Url_Click(object sender, EventArgs e)
-    {
-    }
+        private void Save_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                UpdateConfigurationFromUi();
+                _configuration.Save();
+                MessageBox.Show("Created mu.ini", "NOTICE");
+            }
+            catch (IOException ex)
+            {
+                MessageBox.Show($"Failed to save configuration: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
 
-    private void textBox3_TextChanged(object sender, EventArgs e)
-    {
-    }
+        private void Form1_Load(object sender, EventArgs e)
+        {
+            BindConfigurationToUi(_configuration);
+        }
 
-    protected override void Dispose(bool disposing)
-    {
-      if (disposing && this.components != null)
-        this.components.Dispose();
-      base.Dispose(disposing);
-    }
+        private void BindConfigurationToUi(MuConfiguration configuration)
+        {
+            comboBox1.SelectedIndex = ClampIndex(configuration.SeasonIndex, comboBox1.Items.Count);
+            comboBox2.SelectedIndex = ClampIndex(configuration.LanguageIndex, comboBox2.Items.Count);
+            txtboxName.Text = configuration.LauncherName;
+            textBoxUrl1.Text = configuration.UpdateUrl;
+            textBoxExe.Text = configuration.ExecutableName;
+            textBoxUrl2.Text = configuration.PageUrl;
+        }
 
-    private void InitializeComponent()
-    {
-      ComponentResourceManager componentResourceManager = new ComponentResourceManager(typeof (Form1));
-      this.S12 = new Label();
-      this.Url = new Label();
-      this.textBoxUrl1 = new TextBox();
-      this.comboBox1 = new ComboBox();
-      this.Save = new Button();
-      this.label2 = new Label();
-      this.txtboxName = new TextBox();
-      this.label3 = new Label();
-      this.textBoxExe = new TextBox();
-      this.label4 = new Label();
-      this.textBoxUrl2 = new TextBox();
-      this.label1 = new Label();
-      this.comboBox2 = new ComboBox();
-      this.SuspendLayout();
-      this.S12.AutoSize = true;
-      this.S12.Location = new Point(9, 41);
-      this.S12.Name = "S12";
-      this.S12.Size = new Size(74, 13);
-      this.S12.TabIndex = 0;
-      this.S12.Text = "Client Version:";
-      this.Url.AutoSize = true;
-      this.Url.Location = new Point(9, 68);
-      this.Url.Name = "Url";
-      this.Url.Size = new Size(61, 13);
-      this.Url.TabIndex = 2;
-      this.Url.Text = "Update Url:";
-      this.Url.Click += new EventHandler(this.Url_Click);
-      this.textBoxUrl1.Location = new Point(77, 65);
-      this.textBoxUrl1.Name = "textBoxUrl1";
-      this.textBoxUrl1.Size = new Size(198, 20);
-      this.textBoxUrl1.TabIndex = 3;
-      this.textBoxUrl1.Text = "http://127.0.0.1/update/";
-      this.comboBox1.FormattingEnabled = true;
-      this.comboBox1.Items.AddRange(new object[3]
-      {
-        (object) "Season 6",
-        (object) "Season 9",
-        (object) "Season 12"
-      });
-      this.comboBox1.Location = new Point(99, 38);
-      this.comboBox1.Name = "comboBox1";
-      this.comboBox1.Size = new Size(176, 21);
-      this.comboBox1.TabIndex = 4;
-      this.Save.Location = new Point(99, 169);
-      this.Save.Name = "Save";
-      this.Save.Size = new Size(75, 23);
-      this.Save.TabIndex = 5;
-      this.Save.Text = "Save";
-      this.Save.UseVisualStyleBackColor = true;
-      this.Save.Click += new EventHandler(this.Save_Click);
-      this.label2.AutoSize = true;
-      this.label2.Location = new Point(9, 15);
-      this.label2.Name = "label2";
-      this.label2.Size = new Size(38, 13);
-      this.label2.TabIndex = 7;
-      this.label2.Text = "Name:";
-      this.txtboxName.Enabled = false;
-      this.txtboxName.Location = new Point(77, 12);
-      this.txtboxName.Name = "txtboxName";
-      this.txtboxName.Size = new Size(198, 20);
-      this.txtboxName.TabIndex = 8;
-      this.txtboxName.Text = "Mu Launcher";
-      this.label3.AutoSize = true;
-      this.label3.Location = new Point(9, 120);
-      this.label3.Name = "label3";
-      this.label3.Size = new Size(57, 13);
-      this.label3.TabIndex = 9;
-      this.label3.Text = "Exe name:";
-      this.textBoxExe.Location = new Point(77, 117);
-      this.textBoxExe.Name = "textBoxExe";
-      this.textBoxExe.Size = new Size(198, 20);
-      this.textBoxExe.TabIndex = 10;
-      this.textBoxExe.Text = "main.exe";
-      this.textBoxExe.TextChanged += new EventHandler(this.textBox3_TextChanged);
-      this.label4.AutoSize = true;
-      this.label4.Location = new Point(9, 94);
-      this.label4.Name = "label4";
-      this.label4.Size = new Size(51, 13);
-      this.label4.TabIndex = 11;
-      this.label4.Text = "Page Url:";
-      this.textBoxUrl2.Location = new Point(77, 91);
-      this.textBoxUrl2.Name = "textBoxUrl2";
-      this.textBoxUrl2.Size = new Size(198, 20);
-      this.textBoxUrl2.TabIndex = 12;
-      this.textBoxUrl2.Text = "http://127.0.0.1/update/index.php";
-      this.label1.AutoSize = true;
-      this.label1.Location = new Point(9, 145);
-      this.label1.Name = "label1";
-      this.label1.Size = new Size(106, 13);
-      this.label1.TabIndex = 13;
-      this.label1.Text = "Launcher Language:";
-      this.comboBox2.Enabled = false;
-      this.comboBox2.FormattingEnabled = true;
-      this.comboBox2.Items.AddRange(new object[4]
-      {
-        (object) "Auto",
-        (object) "Eng",
-        (object) "Spn",
-        (object) "Por"
-      });
-      this.comboBox2.Location = new Point(121, 142);
-      this.comboBox2.Name = "comboBox2";
-      this.comboBox2.Size = new Size(154, 21);
-      this.comboBox2.TabIndex = 14;
-      this.AutoScaleDimensions = new SizeF(6f, 13f);
-      this.AutoScaleMode = AutoScaleMode.Font;
-      this.ClientSize = new Size(287, 201);
-      this.Controls.Add((Control) this.comboBox2);
-      this.Controls.Add((Control) this.label1);
-      this.Controls.Add((Control) this.textBoxUrl2);
-      this.Controls.Add((Control) this.label4);
-      this.Controls.Add((Control) this.textBoxExe);
-      this.Controls.Add((Control) this.label3);
-      this.Controls.Add((Control) this.txtboxName);
-      this.Controls.Add((Control) this.label2);
-      this.Controls.Add((Control) this.Save);
-      this.Controls.Add((Control) this.comboBox1);
-      this.Controls.Add((Control) this.textBoxUrl1);
-      this.Controls.Add((Control) this.Url);
-      this.Controls.Add((Control) this.S12);
-      this.Icon = (Icon) componentResourceManager.GetObject("$this.Icon");
-      this.Name = nameof (Form1);
-      this.StartPosition = FormStartPosition.CenterScreen;
-      this.Text = "Config Generator";
-      this.Load += new EventHandler(this.Form1_Load);
-      this.ResumeLayout(false);
-      this.PerformLayout();
+        private void UpdateConfigurationFromUi()
+        {
+            _configuration.SeasonIndex = comboBox1.SelectedIndex;
+            _configuration.LanguageIndex = comboBox2.SelectedIndex;
+            _configuration.LauncherName = txtboxName.Text;
+            _configuration.UpdateUrl = textBoxUrl1.Text;
+            _configuration.ExecutableName = textBoxExe.Text;
+            _configuration.PageUrl = textBoxUrl2.Text;
+        }
+
+        private static int ClampIndex(int value, int count)
+        {
+            if (count <= 0)
+            {
+                return -1;
+            }
+
+            if (value < 0)
+            {
+                return 0;
+            }
+
+            if (value >= count)
+            {
+                return count - 1;
+            }
+
+            return value;
+        }
+
+        private void Url_Click(object sender, EventArgs e)
+        {
+        }
+
+        private void textBox3_TextChanged(object sender, EventArgs e)
+        {
+        }
+
     }
-  }
 }

--- a/ConfigGenerator/MuConfiguration.cs
+++ b/ConfigGenerator/MuConfiguration.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ConfigGenerator
+{
+    /// <summary>
+    /// Encapsulates the serialization logic of the legacy <c>mu.ini</c> file.
+    /// </summary>
+    public sealed class MuConfiguration
+    {
+        private static readonly byte[] XorKey = { 77, 252, 207, 171, byte.MaxValue };
+
+        public const string DefaultFileName = "./mu.ini";
+
+        public int SeasonIndex { get; set; }
+
+        public int LanguageIndex { get; set; }
+
+        public string LauncherName { get; set; } = "Mu Launcher";
+
+        public string UpdateUrl { get; set; } = "http://127.0.0.1/update/";
+
+        public string ExecutableName { get; set; } = "main.exe";
+
+        public string PageUrl { get; set; } = "http://127.0.0.1/update/index.php";
+
+        public static MuConfiguration Load(string path = DefaultFileName)
+        {
+            if (!File.Exists(path))
+            {
+                return new MuConfiguration();
+            }
+
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: false);
+
+            var config = new MuConfiguration
+            {
+                SeasonIndex = reader.ReadInt32(),
+                LanguageIndex = reader.ReadInt32()
+            };
+
+            var encryptedBytes = reader.ReadBytes((int)(reader.BaseStream.Length - reader.BaseStream.Position));
+            var decrypted = ApplyXor(encryptedBytes);
+            var parts = Encoding.UTF8.GetString(decrypted).Split('|');
+
+            config.LauncherName = parts.ElementAtOrDefault(0) ?? config.LauncherName;
+            config.UpdateUrl = parts.ElementAtOrDefault(1) ?? config.UpdateUrl;
+            config.ExecutableName = parts.ElementAtOrDefault(2) ?? config.ExecutableName;
+            config.PageUrl = parts.ElementAtOrDefault(3) ?? config.PageUrl;
+
+            return config;
+        }
+
+        public void Save(string path = DefaultFileName)
+        {
+            using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: false);
+
+            writer.Write(SeasonIndex);
+            writer.Write(LanguageIndex);
+
+            var payload = string.Join("|", LauncherName, UpdateUrl, ExecutableName, PageUrl);
+            var buffer = Encoding.UTF8.GetBytes(payload);
+            var encrypted = ApplyXor(buffer);
+
+            writer.Write(encrypted);
+        }
+
+        private static byte[] ApplyXor(byte[] buffer)
+        {
+            var result = new byte[buffer.Length];
+            for (var i = 0; i < buffer.Length; i++)
+            {
+                result[i] = (byte)(buffer[i] ^ XorKey[i % XorKey.Length]);
+            }
+
+            return result;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Launcher Mod Suite
+
+Este repositório contém três ferramentas legadas relacionadas ao Launcher do jogo MU: **ConfigGenerator**, **Update Generator** e **Launcher**. O objetivo deste documento é consolidar o plano de unificação e análise prévia para a criação de uma ferramenta única que integre esses módulos e acrescente um gerenciador de design.
+
+## Plano estratégico proposto
+
+### 1. Estrutura da solução unificada
+- **Solução principal (`LauncherSuite.sln`)** com quatro projetos:
+  1. `LauncherSuite.Core` (biblioteca de classes) — conterá modelos, serviços e utilitários compartilhados (manipulação do `mu.ini`, cálculo de hashes CRC, abstrações de storage de temas, etc.).
+  2. `LauncherSuite.WinUI` (aplicativo desktop) — janela principal com navegação em abas ou wizard, hospedando os módulos de Configuração, Updates e Design.
+  3. `LauncherSuite.Config` (UserControl) — refatoração do ConfigGenerator original para usar os serviços do núcleo.
+  4. `LauncherSuite.Updates` (UserControl) — refatoração do Update Generator, reutilizando o núcleo para cálculo e cópia.
+  5. `LauncherSuite.Design` (UserControl) — novo módulo de gerenciamento de temas.
+
+### 2. Módulo ConfigGenerator (Refatorado)
+- Extrair lógica de leitura/gravação do `mu.ini` para `LauncherSuite.Core.Configuration`.
+- Converter o formulário WinForms existente em um UserControl; expor eventos/comandos para o shell principal.
+- Implementar validação de campos e suporte a perfis salvos.
+
+### 3. Módulo Update Generator (Refatorado)
+- Migrar cálculo de hashes, geração de manifestos e rotina de cópia para serviços em `LauncherSuite.Core.Updates`.
+- Encapsular configurações padrão (ex.: diretório de saída) e permitir presets.
+- Acrescentar pré-visualização da estrutura do pacote antes da geração.
+
+### 4. Formato de Tema (Design Manager)
+- **Estrutura sugerida**:
+  ```
+  /ThemeName/
+    theme.json            // metadados (nome, autor, versão, compatibilidade)
+    images/
+      background.png
+      buttons/
+        play.png
+        exit.png
+      icons/
+        settings.png
+    fonts/
+    layout.xml            // (opcional) definições de posições/sizes se necessárias
+  ```
+- `theme.json` deve mapear as imagens obrigatórias/opcionais e parâmetros (cores, fontes).
+- Definir contratos em `LauncherSuite.Core.Design` para validar, importar, exportar e aplicar temas.
+
+### 5. Evolução do Launcher para suportar temas
+- Adaptar o Launcher existente para carregar recursos de tema via:
+  - Lookup em `LauncherSuite.Core.Design` e fallback para recursos embutidos.
+  - Monitoramento de alterações (hot reload simples) durante o design.
+- Garantir compatibilidade com Seasons: os temas podem ter variações por Season, referenciadas no `theme.json`.
+
+### 6. Fluxo de Build/Deploy Automatizado
+- Implementar um assistente com etapas sequenciais:
+  1. Seleção/criação de configuração (`mu.ini`).
+  2. Seleção de tema ou criação de novo.
+  3. Geração de pacote de atualização (manifesto + arquivos).
+  4. Resumo final com botões para exportar/empacotar.
+- Opcional: integração com scripts MSBuild/PowerShell para gerar instaladores ou arquivar releases.
+
+### 7. Migração incremental sugerida
+1. Criar `LauncherSuite.Core` e mover lógica compartilhada dos geradores.
+2. Portar ConfigGenerator e Update Generator para UserControls utilizando o núcleo.
+3. Desenvolver o `Design Manager`, começando por importação/validação de temas.
+4. Atualizar Launcher para consumir o novo formato de tema.
+5. Integrar os três módulos na aplicação unificada e adicionar o assistente de build/deploy.
+6. Automatizar testes (ex.: unit tests para parse do `mu.ini`, validação de tema, geração de hashes).
+
+### 8. Considerações adicionais
+- Documentar o formato de tema e APIs internas para facilitar criação de novas skins.
+- Planejar testes com conjuntos de arquivos grandes para validar performance do Update Generator.
+- Avaliar uso de WPF/WinUI 3 para interface moderna, mantendo compatibilidade com controles existentes via hostagem de WinForms quando necessário.
+- Preparar scripts de migração para usuários existentes (importar configurações antigas, temas padrão).
+
+## Análise dos projetos atuais
+
+### ConfigGenerator
+Aplicativo WinForms que gera o arquivo `mu.ini` com XOR simples, permitindo escolher versão do cliente, URLs e nome do executável antes de gravar as preferências com dois índices (versão e idioma) no início do arquivo.
+
+### Update Generator
+Ferramenta WinForms que varre uma pasta, calcula hashes CRC dos arquivos e produz uma lista `update.txt`, além de copiar os arquivos para uma estrutura `./update/` espelhando a hierarquia original para distribuição.
+
+### Launcher
+Carrega `mu.ini`, ativa modos específicos conforme a Season selecionada, atualiza UI e lógica (botões, webview, opções) e consome um conjunto fixo de bitmaps empacotados em `Resources.resx` para compor o design atual.
+
+## Possibilidades de integração
+1. **Camada de domínio compartilhada**
+   - Criar uma biblioteca comum que encapsule leitura/escrita de `mu.ini`, cálculo de hashes e definição de estrutura de atualização. Isso evitaria duplicação de lógica entre módulos WinForms e permitiria expor serviços reutilizáveis pela nova ferramenta integrada.
+
+2. **Interface unificada (WinForms ou WPF)**
+   - Aproveitar os formulários existentes como base para abas ou seções em uma única aplicação: uma aba “Configuração” (ConfigGenerator), outra “Gerador de Updates” (Update Generator) e uma nova “Design Manager”.
+   - Reaproveitar os controles e eventos atuais, movendo-os para UserControls que possam ser hospedados numa janela principal com navegação em abas.
+
+3. **Gerenciador de Design**
+   - O design atual é fixo via recursos estáticos; seria viável adicionar um módulo que gerencie pacotes de imagens (bitmaps) e arquivos `.resx` ou diretórios de temas para gerar builds personalizados do Launcher.
+   - Uma abordagem é permitir importar/exportar conjuntos de imagens e gerar automaticamente um `Resources.resx` temático ou aplicar temas via arquivos externos lidos em tempo de execução, reduzindo necessidade de recompilação.
+
+## Considerações técnicas e desafios
+- **Refatoração de código decompilado**: os arquivos foram obtidos por engenharia reversa e carecem de padrões modernos (ex.: ausência de `using` seguros, nomes pouco expressivos). Antes de integrar, seria prudente refatorar para melhorar manutenibilidade.
+- **Persistência do design**: como o Launcher espera recursos embutidos, será preciso definir como novos designs serão carregados (ex.: extraindo para pastas ou gerando builds). Alterar o Launcher para suportar skins externas exigirá ajustes para carregar bitmaps dinamicamente.
+- **Compatibilidade com Seasons**: o `mu.ini` guarda índice da Season e idioma; qualquer integração deve preservar essa lógica para que o Launcher continue habilitando modos Season 9/12 corretamente.
+- **Processo de atualização**: o gerador de updates copia arquivos para `./update/` e lista `.rar` virtual (note que a extensão `.rar` é apenas parte da string). Se a nova ferramenta alterar esse comportamento, o fluxo do patcher precisa ser validado para evitar inconsistências.
+
+## Recomendações finais
+1. Criar uma solução única em C# contendo projetos de biblioteca (núcleo) e um aplicativo principal que hospede os três módulos, com foco em reutilização.
+2. Definir formato de tema padronizado para facilitar criação de pacotes de design.
+3. Automatizar o fluxo de build/deploy para reduzir erros manuais.
+4. Planejar uma migração incremental começando pela extração da lógica compartilhada dos geradores, seguida pela integração dos módulos em uma única ferramenta.
+

--- a/Update Generator/Update Generator.csproj
+++ b/Update Generator/Update Generator.csproj
@@ -38,7 +38,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Cyclic\Redundancy\Check\CRC.cs" />
-    <Compile Include="lForm.cs" />
+    <Compile Include="lForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="lForm.Designer.cs">
+      <DependentUpon>lForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UpdateManifestBuilder.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\Resources.cs" />
     <Compile Include="Properties\Settings.cs" />

--- a/Update Generator/UpdateManifestBuilder.cs
+++ b/Update Generator/UpdateManifestBuilder.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cyclic.Redundancy.Check;
+
+namespace Update.Maker
+{
+    public sealed class UpdateManifestBuilder
+    {
+        private readonly CRC _crc = new CRC();
+
+        public ManifestBuildResult Build(string sourcePath, string outputDirectory, IProgress<ManifestProgress>? progress = null)
+        {
+            if (string.IsNullOrWhiteSpace(sourcePath))
+            {
+                throw new ArgumentException("Source path must be provided.", nameof(sourcePath));
+            }
+
+            var absoluteSource = Path.GetFullPath(sourcePath);
+            var files = Directory.EnumerateFiles(absoluteSource, "*", SearchOption.AllDirectories).ToList();
+
+            Directory.CreateDirectory(outputDirectory);
+
+            var entries = new List<UpdateManifestEntry>(files.Count);
+            for (var index = 0; index < files.Count; index++)
+            {
+                var file = files[index];
+                var entry = CreateEntry(absoluteSource, outputDirectory, file);
+                entries.Add(entry);
+                progress?.Report(new ManifestProgress(index + 1, files.Count, entry));
+            }
+
+            return new ManifestBuildResult(entries);
+        }
+
+        private UpdateManifestEntry CreateEntry(string sourceRoot, string outputDirectory, string file)
+        {
+            var relativePath = Path.GetRelativePath(sourceRoot, file);
+            var normalizedRelativePath = relativePath.Replace("\\", "/");
+            var destinationPath = Path.Combine(outputDirectory, relativePath);
+            var destinationDirectory = Path.GetDirectoryName(destinationPath);
+
+            if (!string.IsNullOrEmpty(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            File.Copy(file, destinationPath, true);
+
+            return new UpdateManifestEntry(
+                normalizedRelativePath,
+                ComputeHash(file),
+                new FileInfo(file).Length);
+        }
+
+        private string ComputeHash(string path)
+        {
+            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var hash = _crc.ComputeHash(stream);
+            return string.Concat(hash.Select(b => b.ToString("X2")));
+        }
+    }
+
+    public sealed record UpdateManifestEntry(string RelativePath, string Hash, long Size)
+    {
+        public string ManifestPath => RelativePath + ".rar";
+
+        public string ToManifestLine() => string.Join(";", ManifestPath, Hash, Size);
+    }
+
+    public readonly record struct ManifestProgress(int Processed, int Total, UpdateManifestEntry Entry)
+    {
+        public int Percentage => Total == 0 ? 0 : (int)Math.Round((double)Processed / Total * 100, MidpointRounding.AwayFromZero);
+    }
+
+    public sealed record ManifestBuildResult(IReadOnlyList<UpdateManifestEntry> Entries)
+    {
+        public string ToManifestText()
+        {
+            if (Entries.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(Environment.NewLine, Entries.Select(entry => entry.ToManifestLine())) + Environment.NewLine;
+        }
+    }
+}

--- a/Update Generator/lForm.Designer.cs
+++ b/Update Generator/lForm.Designer.cs
@@ -1,0 +1,160 @@
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Update.Maker
+{
+    public partial class lForm
+    {
+        private TextBox Result;
+        private Button browseButton;
+        private ProgressBar Progress;
+        private Button saveButton;
+        private BackgroundWorker backgroundWorker;
+        private FolderBrowserDialog folderBrowserDialog;
+        private TextBox filePath;
+        private Button removeButton;
+        private SaveFileDialog saveFileDialog;
+        private GroupBox groupBox1;
+        private GroupBox groupBox2;
+        private IContainer components;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            var componentResourceManager = new ComponentResourceManager(typeof(lForm));
+            components = new Container();
+            Result = new TextBox();
+            browseButton = new Button();
+            Progress = new ProgressBar();
+            saveButton = new Button();
+            backgroundWorker = new BackgroundWorker();
+            components.Add(backgroundWorker);
+            folderBrowserDialog = new FolderBrowserDialog();
+            filePath = new TextBox();
+            removeButton = new Button();
+            saveFileDialog = new SaveFileDialog();
+            groupBox1 = new GroupBox();
+            groupBox2 = new GroupBox();
+            groupBox1.SuspendLayout();
+            SuspendLayout();
+            // 
+            // Result
+            // 
+            Result.BorderStyle = BorderStyle.FixedSingle;
+            Result.Font = new Font("Microsoft Sans Serif", 8F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            Result.Location = new Point(224, 19);
+            Result.Multiline = true;
+            Result.Name = "Result";
+            Result.ScrollBars = ScrollBars.Vertical;
+            Result.Size = new Size(473, 280);
+            Result.TabIndex = 0;
+            // 
+            // browseButton
+            // 
+            browseButton.Location = new Point(25, 28);
+            browseButton.Name = "browseButton";
+            browseButton.Size = new Size(154, 47);
+            browseButton.TabIndex = 1;
+            browseButton.Text = "1. Select Folder";
+            browseButton.UseVisualStyleBackColor = true;
+            browseButton.Click += browseButton_Click;
+            // 
+            // Progress
+            // 
+            Progress.Location = new Point(224, 305);
+            Progress.Name = "Progress";
+            Progress.Size = new Size(457, 19);
+            Progress.TabIndex = 2;
+            Progress.Click += Progress_Click;
+            // 
+            // saveButton
+            // 
+            saveButton.Enabled = false;
+            saveButton.Location = new Point(25, 92);
+            saveButton.Name = "saveButton";
+            saveButton.Size = new Size(154, 44);
+            saveButton.TabIndex = 3;
+            saveButton.Text = "2. Save List";
+            saveButton.UseVisualStyleBackColor = true;
+            saveButton.Click += saveButton_Click;
+            // 
+            // backgroundWorker
+            // 
+            backgroundWorker.WorkerReportsProgress = true;
+            backgroundWorker.DoWork += backgroundWorker_DoWork;
+            backgroundWorker.ProgressChanged += backgroundWorker_ProgressChanged;
+            backgroundWorker.RunWorkerCompleted += backgroundWorker_RunWorkerCompleted;
+            // 
+            // filePath
+            // 
+            filePath.Location = new Point(25, 227);
+            filePath.MaxLength = 256;
+            filePath.Name = "filePath";
+            filePath.Size = new Size(154, 20);
+            filePath.TabIndex = 4;
+            filePath.Visible = false;
+            filePath.TextChanged += filePath_TextChanged;
+            // 
+            // removeButton
+            // 
+            removeButton.Enabled = false;
+            removeButton.Location = new Point(71, 253);
+            removeButton.Name = "removeButton";
+            removeButton.Size = new Size(58, 23);
+            removeButton.TabIndex = 5;
+            removeButton.Text = "Remove";
+            removeButton.UseVisualStyleBackColor = true;
+            removeButton.Visible = false;
+            removeButton.Click += removeButton_Click;
+            // 
+            // groupBox1
+            // 
+            groupBox1.Controls.Add(groupBox2);
+            groupBox1.Controls.Add(Result);
+            groupBox1.Controls.Add(removeButton);
+            groupBox1.Controls.Add(saveButton);
+            groupBox1.Controls.Add(Progress);
+            groupBox1.Controls.Add(browseButton);
+            groupBox1.Controls.Add(filePath);
+            groupBox1.Location = new Point(15, 5);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Size = new Size(703, 332);
+            groupBox1.TabIndex = 100;
+            groupBox1.TabStop = false;
+            // 
+            // groupBox2
+            // 
+            groupBox2.Location = new Point(203, 10);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Size = new Size(5, 314);
+            groupBox2.TabIndex = 6;
+            groupBox2.TabStop = false;
+            // 
+            // lForm
+            // 
+            AutoScaleDimensions = new SizeF(6F, 13F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(730, 349);
+            Controls.Add(groupBox1);
+            Icon = (Icon)componentResourceManager.GetObject("$this.Icon");
+            MaximizeBox = false;
+            Name = "lForm";
+            ShowIcon = false;
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Update Generator";
+            groupBox1.ResumeLayout(false);
+            groupBox1.PerformLayout();
+            ResumeLayout(false);
+        }
+    }
+}

--- a/Update Generator/lForm.cs
+++ b/Update Generator/lForm.cs
@@ -1,269 +1,161 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: Update.Maker.lForm
-// Assembly: Generator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-// MVID: 9F664580-F6B4-4B6D-A5C6-C03B862A74BB
-// Assembly location: C:\Users\Rafael Mazzoni\Documents\Ideias de Revenda\RetroSix\Free Mu CMS 1.2.3\Launcher Free\Launcher Free\Generator\Update Generator.exe
-
-using Cyclic.Redundancy.Check;
 using System;
 using System.ComponentModel;
-using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
 
 namespace Update.Maker
 {
-  public class lForm : Form
-  {
-    private string[] Files;
-    private IContainer components;
-    private TextBox Result;
-    private Button browseButton;
-    private ProgressBar Progress;
-    private Button saveButton;
-    private BackgroundWorker backgroundWorker;
-    private FolderBrowserDialog folderBrowserDialog;
-    private TextBox filePath;
-    private Button removeButton;
-    private SaveFileDialog saveFileDialog;
-    private GroupBox groupBox1;
-    private GroupBox groupBox2;
-
-    public lForm() => this.InitializeComponent();
-
-    private void browseButton_Click(object sender, EventArgs e)
+    public partial class lForm : Form
     {
-      Directory.CreateDirectory(".\\\\update");
-      this.StartBrowsing();
-    }
+        private readonly UpdateManifestBuilder _manifestBuilder = new UpdateManifestBuilder();
+        private ManifestBuildResult _lastBuild = new ManifestBuildResult(Array.Empty<UpdateManifestEntry>());
+        private string _selectedPath = string.Empty;
 
-    private void saveButton_Click(object sender, EventArgs e) => this.SaveList();
-
-    private void removeButton_Click(object sender, EventArgs e) => this.RemoveFromPath(this.filePath.Text);
-
-    private void backgroundWorker_DoWork(object sender, DoWorkEventArgs e)
-    {
-      this.Files = this.GetFiles(e.Argument);
-      for (int index = 0; index < this.Files.Length; ++index)
-        this.backgroundWorker.ReportProgress(index + 1, (object) this.GetFileData(this.Files[index]));
-    }
-
-    private void backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
-    {
-      this.UpdateResult(e.UserState);
-      this.UpdateProgressBar(this.ComputeProgress(e.ProgressPercentage));
-    }
-
-    private void backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e) => this.EnableButtons();
-
-    private void DisableButtons()
-    {
-      this.Progress.Value = 0;
-      this.Result.Clear();
-      this.saveButton.Enabled = false;
-      this.removeButton.Enabled = false;
-      this.browseButton.Enabled = false;
-    }
-
-    private void EnableButtons()
-    {
-      this.saveButton.Enabled = true;
-      this.removeButton.Enabled = true;
-      this.browseButton.Enabled = true;
-    }
-
-    public string[] GetFiles(object Path) => Directory.GetFiles(Path.ToString(), "*.*", SearchOption.AllDirectories);
-
-    public int GetFilesCount(string[] Files) => Files.Length;
-
-    public string GetFileData(string File)
-    {
-      FileInfo fileInfo = new FileInfo(File);
-      return File + ".rar;" + this.GetHash(File) + ";" + (object) fileInfo.Length;
-    }
-
-    private string GetHash(string Name)
-    {
-      if (Name == string.Empty)
-        return (string) null;
-      CRC crc = new CRC();
-      string empty = string.Empty;
-      try
-      {
-        using (FileStream inputStream = File.Open(Name, FileMode.Open))
+        public lForm()
         {
-          foreach (byte num in crc.ComputeHash((Stream) inputStream))
-            empty += num.ToString("x2").ToUpper();
+            InitializeComponent();
         }
-      }
-      catch
-      {
-        int num = (int) MessageBox.Show("Can't open: " + Name);
-      }
-      return empty;
-    }
 
-    private void UpdateResult(object Data)
-    {
-      if (this.Result.IsDisposed)
-        return;
-      string path = Data.ToString().Replace("\\", "/").Split(';')[0].Replace(this.filePath.Text, string.Empty);
-      if (path.Contains("/"))
-        Directory.CreateDirectory("./update/" + Path.GetDirectoryName(path));
-      File.Copy(Data.ToString().Replace("\\", "/").Split(';')[0].Replace(".rar", string.Empty), Directory.GetCurrentDirectory() + "/update/" + path, true);
-      this.Result.AppendText(Data.ToString().Replace("\\", "/").Replace(this.filePath.Text, string.Empty) + Environment.NewLine);
-    }
+        private void browseButton_Click(object sender, EventArgs e)
+        {
+            if (folderBrowserDialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
 
-    private int ComputeProgress(int Percent) => 100 * Percent / this.Files.Length;
+            _selectedPath = folderBrowserDialog.SelectedPath;
+            filePath.Text = NormalizePath(_selectedPath);
+            BeginBuild();
+        }
 
-    private void UpdateProgressBar(int Percent)
-    {
-      if (Percent < 0 || Percent > 100 || this.Progress.IsDisposed)
-        return;
-      this.Progress.Value = Percent;
-    }
+        private void saveButton_Click(object sender, EventArgs e)
+        {
+            SaveManifest();
+        }
 
-    private void RemoveFromPath(string Remove)
-    {
-      if (Remove == string.Empty)
-        return;
-      this.Result.Text = this.Result.Text.Replace(Remove, string.Empty);
-      this.filePath.Text = this.filePath.Text.Replace(Remove, string.Empty);
-    }
+        private void removeButton_Click(object sender, EventArgs e)
+        {
+            ClearSelection();
+        }
 
-    private void StartBrowsing()
-    {
-      if (this.folderBrowserDialog.ShowDialog() != DialogResult.OK)
-        return;
-      this.DisableButtons();
-      this.filePath.Text = this.folderBrowserDialog.SelectedPath.Replace("\\", "/") + "/";
-      if (this.backgroundWorker.IsBusy)
-        return;
-      this.backgroundWorker.RunWorkerAsync((object) this.folderBrowserDialog.SelectedPath);
-    }
+        private void backgroundWorker_DoWork(object sender, DoWorkEventArgs e)
+        {
+            var path = (string)e.Argument;
+            var updateDirectory = Path.Combine(Directory.GetCurrentDirectory(), "update");
+            var progress = new Progress<ManifestProgress>(p => backgroundWorker.ReportProgress(p.Percentage, p));
+            Directory.CreateDirectory(updateDirectory);
+            e.Result = _manifestBuilder.Build(path, updateDirectory, progress);
+        }
 
-    private void SaveList()
-    {
-      this.saveFileDialog.FileName = "update.txt";
-      this.saveFileDialog.InitialDirectory = Directory.GetCurrentDirectory() + "\\update\\";
-      this.saveFileDialog.RestoreDirectory = true;
-      this.saveFileDialog.Filter = "Text files (*.txt)|*.txt|Every file (*.*)|*.*";
-      if (this.saveFileDialog.ShowDialog() != DialogResult.OK)
-        return;
-      using (StreamWriter streamWriter = new StreamWriter(this.saveFileDialog.FileName))
-        streamWriter.Write(this.Result.Text);
-    }
+        private void backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
+        {
+            if (e.UserState is ManifestProgress progress)
+            {
+                UpdateProgress(progress);
+            }
+        }
 
-    private void Progress_Click(object sender, EventArgs e)
-    {
-    }
+        private void backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
+        {
+            EnableButtons();
 
-    private void filePath_TextChanged(object sender, EventArgs e)
-    {
-    }
+            if (e.Error != null)
+            {
+                Result.Clear();
+                MessageBox.Show($"Failed to generate update list: {e.Error.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
 
-    protected override void Dispose(bool disposing)
-    {
-      if (disposing && this.components != null)
-        this.components.Dispose();
-      base.Dispose(disposing);
-    }
+            if (e.Result is ManifestBuildResult buildResult)
+            {
+                _lastBuild = buildResult;
+            }
+        }
 
-    private void InitializeComponent()
-    {
-      ComponentResourceManager componentResourceManager = new ComponentResourceManager(typeof (lForm));
-      this.Result = new TextBox();
-      this.browseButton = new Button();
-      this.Progress = new ProgressBar();
-      this.saveButton = new Button();
-      this.backgroundWorker = new BackgroundWorker();
-      this.folderBrowserDialog = new FolderBrowserDialog();
-      this.filePath = new TextBox();
-      this.removeButton = new Button();
-      this.saveFileDialog = new SaveFileDialog();
-      this.groupBox1 = new GroupBox();
-      this.groupBox2 = new GroupBox();
-      this.groupBox1.SuspendLayout();
-      this.SuspendLayout();
-      this.Result.BorderStyle = BorderStyle.FixedSingle;
-      this.Result.Font = new Font("Microsoft Sans Serif", 8f, FontStyle.Regular, GraphicsUnit.Point, (byte) 0);
-      this.Result.Location = new Point(224, 19);
-      this.Result.Multiline = true;
-      this.Result.Name = "Result";
-      this.Result.ScrollBars = ScrollBars.Vertical;
-      this.Result.Size = new Size(473, 280);
-      this.Result.TabIndex = 0;
-      this.browseButton.Location = new Point(25, 28);
-      this.browseButton.Name = "browseButton";
-      this.browseButton.Size = new Size(154, 47);
-      this.browseButton.TabIndex = 1;
-      this.browseButton.Text = "1. Select Folder";
-      this.browseButton.UseVisualStyleBackColor = true;
-      this.browseButton.Click += new EventHandler(this.browseButton_Click);
-      this.Progress.BackColor = SystemColors.Control;
-      this.Progress.Location = new Point(224, 305);
-      this.Progress.Name = "Progress";
-      this.Progress.Size = new Size(457, 19);
-      this.Progress.TabIndex = 2;
-      this.Progress.Click += new EventHandler(this.Progress_Click);
-      this.saveButton.Enabled = false;
-      this.saveButton.Location = new Point(25, 92);
-      this.saveButton.Name = "saveButton";
-      this.saveButton.Size = new Size(154, 44);
-      this.saveButton.TabIndex = 3;
-      this.saveButton.Text = "2. Save List";
-      this.saveButton.UseVisualStyleBackColor = true;
-      this.saveButton.Click += new EventHandler(this.saveButton_Click);
-      this.backgroundWorker.WorkerReportsProgress = true;
-      this.backgroundWorker.DoWork += new DoWorkEventHandler(this.backgroundWorker_DoWork);
-      this.backgroundWorker.ProgressChanged += new ProgressChangedEventHandler(this.backgroundWorker_ProgressChanged);
-      this.backgroundWorker.RunWorkerCompleted += new RunWorkerCompletedEventHandler(this.backgroundWorker_RunWorkerCompleted);
-      this.filePath.Location = new Point(25, 227);
-      this.filePath.MaxLength = 256;
-      this.filePath.Name = "filePath";
-      this.filePath.Size = new Size(154, 20);
-      this.filePath.TabIndex = 4;
-      this.filePath.Visible = false;
-      this.filePath.TextChanged += new EventHandler(this.filePath_TextChanged);
-      this.removeButton.Enabled = false;
-      this.removeButton.Location = new Point(71, 253);
-      this.removeButton.Name = "removeButton";
-      this.removeButton.Size = new Size(58, 23);
-      this.removeButton.TabIndex = 5;
-      this.removeButton.Text = "Remove";
-      this.removeButton.UseVisualStyleBackColor = true;
-      this.removeButton.Visible = false;
-      this.removeButton.Click += new EventHandler(this.removeButton_Click);
-      this.groupBox1.Controls.Add((Control) this.groupBox2);
-      this.groupBox1.Controls.Add((Control) this.Result);
-      this.groupBox1.Controls.Add((Control) this.removeButton);
-      this.groupBox1.Controls.Add((Control) this.saveButton);
-      this.groupBox1.Controls.Add((Control) this.Progress);
-      this.groupBox1.Controls.Add((Control) this.browseButton);
-      this.groupBox1.Controls.Add((Control) this.filePath);
-      this.groupBox1.Location = new Point(15, 5);
-      this.groupBox1.Name = "groupBox1";
-      this.groupBox1.Size = new Size(703, 332);
-      this.groupBox1.TabIndex = 100;
-      this.groupBox1.TabStop = false;
-      this.groupBox2.Location = new Point(203, 10);
-      this.groupBox2.Name = "groupBox2";
-      this.groupBox2.Size = new Size(5, 314);
-      this.groupBox2.TabIndex = 6;
-      this.groupBox2.TabStop = false;
-      this.AutoScaleDimensions = new SizeF(6f, 13f);
-      this.AutoScaleMode = AutoScaleMode.Font;
-      this.ClientSize = new Size(730, 349);
-      this.Controls.Add((Control) this.groupBox1);
-      this.Icon = (Icon) componentResourceManager.GetObject("$this.Icon");
-      this.MaximizeBox = false;
-      this.Name = nameof (lForm);
-      this.ShowIcon = false;
-      this.StartPosition = FormStartPosition.CenterScreen;
-      this.Text = "Update Generator";
-      this.groupBox1.ResumeLayout(false);
-      this.groupBox1.PerformLayout();
-      this.ResumeLayout(false);
+        private void BeginBuild()
+        {
+            if (string.IsNullOrEmpty(_selectedPath))
+            {
+                return;
+            }
+
+            if (backgroundWorker.IsBusy)
+            {
+                return;
+            }
+
+            DisableButtons();
+            Result.Clear();
+            Progress.Value = 0;
+            backgroundWorker.RunWorkerAsync(_selectedPath);
+        }
+
+        private void UpdateProgress(ManifestProgress progress)
+        {
+            Result.AppendText(progress.Entry.ToManifestLine() + Environment.NewLine);
+            Progress.Value = Clamp(progress.Percentage, 0, 100);
+        }
+
+        private void SaveManifest()
+        {
+            if (_lastBuild.Entries.Count == 0)
+            {
+                MessageBox.Show("Nothing to save. Generate the manifest first.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            saveFileDialog.FileName = "update.txt";
+            saveFileDialog.InitialDirectory = Path.Combine(Directory.GetCurrentDirectory(), "update");
+            saveFileDialog.RestoreDirectory = true;
+            saveFileDialog.Filter = "Text files (*.txt)|*.txt|Every file (*.*)|*.*";
+
+            if (saveFileDialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            File.WriteAllText(saveFileDialog.FileName, _lastBuild.ToManifestText());
+        }
+
+        private void ClearSelection()
+        {
+            _selectedPath = string.Empty;
+            filePath.Clear();
+            Result.Clear();
+            Progress.Value = 0;
+            _lastBuild = new ManifestBuildResult(Array.Empty<UpdateManifestEntry>());
+            DisableSaveButtons();
+        }
+
+        private void DisableButtons()
+        {
+            browseButton.Enabled = false;
+            DisableSaveButtons();
+        }
+
+        private void EnableButtons()
+        {
+            browseButton.Enabled = true;
+            saveButton.Enabled = _lastBuild.Entries.Count > 0;
+            removeButton.Enabled = !string.IsNullOrEmpty(_selectedPath);
+        }
+
+        private void DisableSaveButtons()
+        {
+            saveButton.Enabled = false;
+            removeButton.Enabled = false;
+        }
+
+        private static int Clamp(int value, int min, int max) => Math.Max(min, Math.Min(max, value));
+
+        private static string NormalizePath(string path) => path.Replace("\\", "/");
+
+        private void filePath_TextChanged(object sender, EventArgs e)
+        {
+        }
+
+        private void Progress_Click(object sender, EventArgs e)
+        {
+        }
     }
-  }
 }


### PR DESCRIPTION
## Summary
- replace the config generator form logic with a dedicated MuConfiguration serializer and designer partial
- introduce an update manifest builder with progress reporting and clean UI separation for the update generator

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d443342c8883329ac058dfe44fcef6